### PR TITLE
feat/#28485 - Adds support for DB2 in AWS RDS

### DIFF
--- a/packages/aws-cdk-lib/aws-rds/test/db2/db2.instance-engine.test.ts
+++ b/packages/aws-cdk-lib/aws-rds/test/db2/db2.instance-engine.test.ts
@@ -1,0 +1,28 @@
+import { Template } from '../../../assertions';
+import * as core from '../../../core';
+import * as rds from '../../lib';
+
+describe('DB2 server instance engine', () => {
+  describe('DB2 instance engine versions', () => {
+    test("has MajorEngineVersion ending in '11.5' for major version 11.5", () => {
+      const stack = new core.Stack();
+      new rds.OptionGroup(stack, 'OptionGroup', {
+        engine: rds.DatabaseInstanceEngine.db2Se({
+          version: rds.Db2EngineVersion.VER_11_5,
+        }),
+        configurations: [
+          {
+            name: 'DB2_BACKUP_RESTORE',
+            settings: {
+              IAM_ROLE_ARN: 'some-role-arn',
+            },
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties('AWS::RDS::OptionGroup', {
+        MajorEngineVersion: '11.5',
+      });
+    });
+  });
+});

--- a/packages/aws-cdk-lib/aws-rds/test/instance.test.ts
+++ b/packages/aws-cdk-lib/aws-rds/test/instance.test.ts
@@ -1030,7 +1030,8 @@ describe('instance', () => {
     const tzSupportedEngines = [rds.DatabaseInstanceEngine.SQL_SERVER_EE, rds.DatabaseInstanceEngine.SQL_SERVER_EX,
       rds.DatabaseInstanceEngine.SQL_SERVER_SE, rds.DatabaseInstanceEngine.SQL_SERVER_WEB];
     const tzUnsupportedEngines = [rds.DatabaseInstanceEngine.MYSQL, rds.DatabaseInstanceEngine.POSTGRES,
-      rds.DatabaseInstanceEngine.ORACLE_EE, rds.DatabaseInstanceEngine.MARIADB];
+      rds.DatabaseInstanceEngine.ORACLE_EE, rds.DatabaseInstanceEngine.MARIADB, rds.DatabaseInstanceEngine.DB2_SE,
+      rds.DatabaseInstanceEngine.DB2_AE];
 
     // THEN
     tzSupportedEngines.forEach((engine) => {
@@ -1349,7 +1350,8 @@ describe('instance', () => {
   test('throws when domain is set for mariadb database engine', () => {
     const domainSupportedEngines = [rds.DatabaseInstanceEngine.SQL_SERVER_EE, rds.DatabaseInstanceEngine.SQL_SERVER_EX,
       rds.DatabaseInstanceEngine.SQL_SERVER_SE, rds.DatabaseInstanceEngine.SQL_SERVER_WEB, rds.DatabaseInstanceEngine.MYSQL,
-      rds.DatabaseInstanceEngine.POSTGRES, rds.DatabaseInstanceEngine.ORACLE_EE];
+      rds.DatabaseInstanceEngine.POSTGRES, rds.DatabaseInstanceEngine.ORACLE_EE, rds.DatabaseInstanceEngine.DB2_SE,
+      rds.DatabaseInstanceEngine.DB2_AE];
     const domainUnsupportedEngines = [rds.DatabaseInstanceEngine.MARIADB];
 
     // THEN

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/rotation-schedule.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/rotation-schedule.ts
@@ -249,6 +249,16 @@ export class HostedRotation implements ec2.IConnectable {
     return new HostedRotation(HostedRotationType.ORACLE_MULTI_USER, options, options.masterSecret);
   }
 
+  /** DB2 Single User */
+  public static db2SingleUser(options: SingleUserHostedRotationOptions = {}) {
+    return new HostedRotation(HostedRotationType.DB2_SINGLE_USER, options);
+  }
+
+  /** DB2 Multi User */
+  public static db2MultiUser(options: MultiUserHostedRotationOptions) {
+    return new HostedRotation(HostedRotationType.DB2_MULTI_USER, options, options.masterSecret);
+  }
+
   /** MariaDB Single User */
   public static mariaDbSingleUser(options: SingleUserHostedRotationOptions = {}) {
     return new HostedRotation(HostedRotationType.MARIADB_SINGLE_USER, options);
@@ -411,6 +421,12 @@ export class HostedRotationType {
   /** MongoDB Multi User */
   public static readonly MONGODB_MULTI_USER = new HostedRotationType('MongoDBMultiUser', true);
 
+  /** DB2 Single User */
+  public static readonly DB2_SINGLE_USER = new HostedRotationType('Db2SingleUser');
+
+  /** DB2 Multi User */
+  public static readonly DB2_MULTI_USER = new HostedRotationType('Db2MultiUser', true);
+  
   /**
    * @param name The type of rotation
    * @param isMultiUser Whether the rotation uses the mutli user scheme

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/secret-rotation.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/secret-rotation.ts
@@ -58,6 +58,18 @@ export class SecretRotationApplication {
   });
 
   /**
+   * Conducts an AWS SecretsManager secret rotation for RDS DB2 using the single user rotation scheme
+   */
+  public static readonly DB2_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSDb2RotationSingleUser', '1.1.367');
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS DB2 using the multi user rotation scheme
+   */
+  public static readonly DB2_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSDb2RotationMultiUser', '1.1.367', {
+    isMultiUser: true,
+  });
+
+  /**
    * Conducts an AWS SecretsManager secret rotation for RDS PostgreSQL using the single user rotation scheme
    */
   public static readonly POSTGRES_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSPostgreSQLRotationSingleUser', '1.1.367');

--- a/packages/aws-cdk-lib/aws-secretsmanager/lib/secret-rotation.ts
+++ b/packages/aws-cdk-lib/aws-secretsmanager/lib/secret-rotation.ts
@@ -60,12 +60,12 @@ export class SecretRotationApplication {
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS DB2 using the single user rotation scheme
    */
-  public static readonly DB2_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSDb2RotationSingleUser', '1.1.367');
+  public static readonly DB2_ROTATION_SINGLE_USER = new SecretRotationApplication('SecretsManagerRDSDb2RotationSingleUser', '1.1.15');
 
   /**
    * Conducts an AWS SecretsManager secret rotation for RDS DB2 using the multi user rotation scheme
    */
-  public static readonly DB2_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSDb2RotationMultiUser', '1.1.367', {
+  public static readonly DB2_ROTATION_MULTI_USER = new SecretRotationApplication('SecretsManagerRDSDb2RotationMultiUser', '1.1.17', {
     isMultiUser: true,
   });
 


### PR DESCRIPTION
```
import {
    App, Stack,
    aws_ec2 as ec2,
    Duration,
    RemovalPolicy,
  } from 'aws-cdk-lib';
import { Connections, InstanceClass, InstanceSize, InstanceType, Port, SecurityGroup, SubnetType } from 'aws-cdk-lib/aws-ec2';
import { Credentials, DatabaseInstance, DatabaseInstanceEngine, Db2EngineVersion, LicenseModel, ParameterGroup, StorageType } from 'aws-cdk-lib/aws-rds';
  const [dbName, dbUsername, dbPort] = ["myDBName", "myDB2Username", 50000];
  const app = new App();
  const london = { region: "eu-west-2", account: process.env.CDK_DEFAULT_ACCOUNT" };
  const paris = { region: "eu-west-3", account: process.env.CDK_DEFAULT_ACCOUNT };
  const stackId = "myDB2TestStack";
  const stack = new Stack(app, stackId, { env: paris });

  // Create VPC
  const vpc = new ec2.Vpc(stack, `${stackId}VPC`, { maxAzs: 2, restrictDefaultSecurityGroup: false, subnetConfiguration: [
    {
        name: 'isolated',
        subnetType: SubnetType.PRIVATE_ISOLATED,
        cidrMask: 22
      }
  ] });

  // Create security group
  const securityGroup = new SecurityGroup(stack, `${stackId}SecurityGroup`, {
    vpc,
    allowAllOutbound: false
  });;

  // Generate & store db credentials with secrets manager
  const credentials = Credentials.fromGeneratedSecret(dbUsername, {
    secretName: `${stackId}SecretName`
  });

  // Create a param group intended to store IBM DB2 license
  const pGroup = new ParameterGroup(stack, `${stackId}ParamGroup`, {
    engine: DatabaseInstanceEngine.db2Se({ version: Db2EngineVersion.VER_11_5 }),
  })
  pGroup.addParameter("rds.ibm_customer_id", "XXXXXXXXX");
  pGroup.addParameter("rds.ibm_site_id", "XXXXXXXXXXX");
  
  // force cloud formation param group generation:
  // https://github.com/aws/aws-cdk/issues/9741
  pGroup.bindToInstance({}); 

  new DatabaseInstance(stack, `${stackId}DBInstance`, {
    vpc,
    engine: DatabaseInstanceEngine.db2Se({version: Db2EngineVersion.VER_11_5}),
    instanceType: InstanceType.of(InstanceClass.M6I, InstanceSize.LARGE),
    securityGroups: [securityGroup],
    vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
    port: dbPort,
    databaseName: dbName,
    monitoringInterval: Duration.seconds(30),
    storageEncrypted: true,
    backupRetention: Duration.days(30),
    removalPolicy: RemovalPolicy.DESTROY,
    credentials: credentials,
    licenseModel: LicenseModel.BRING_YOUR_OWN_LICENSE, // mandatory
    parameterGroup: pGroup,
    storageType: StorageType.IO1 // Prevent "Invalid storage type for DB engine db2-se: gp2"
  });
`
``